### PR TITLE
SDK 19+ External Storage (SD Card) Not working along with SDK 26+ not working from internal storage

### DIFF
--- a/libary/src/main/java/net/alhazmy13/mediapicker/FileProcessing.java
+++ b/libary/src/main/java/net/alhazmy13/mediapicker/FileProcessing.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.text.TextUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -40,6 +41,8 @@ public class FileProcessing {
 
         // DocumentProvider
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            String filePath = "";
+
             // ExternalStorageProvider
             if (isExternalStorageDocument(uri)) {
                 final String docId = DocumentsContract.getDocumentId(uri);
@@ -49,13 +52,29 @@ public class FileProcessing {
                 if ("primary".equalsIgnoreCase(type)) {
                     return Environment.getExternalStorageDirectory() + "/" + split[1];
                 }
-
-                // TODO handle non-primary volumes
+                else {
+                    if (Build.VERSION.SDK_INT > 20) {
+                        //getExternalMediaDirs() added in API 21
+                        File external[] = context.getExternalMediaDirs();
+                        if (external.length > 1) {
+                            filePath = external[1].getAbsolutePath();
+                            filePath = filePath.substring(0, filePath.indexOf("Android")) + split[1];
+                        }
+                    }else{
+                        filePath = "/storage/" + type + "/" + split[1];
+                    }
+                    return filePath;
+                }
             }
             // DownloadsProvider
             else if (isDownloadsDocument(uri)) {
 
                 final String id = DocumentsContract.getDocumentId(uri);
+                if (!TextUtils.isEmpty(id)) {
+                    if (id.startsWith("raw:")) {
+                        return id.replaceFirst("raw:", "");
+                    }
+                }
                 final Uri contentUri = ContentUris.withAppendedId(
                         Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
 


### PR DESCRIPTION
Fix for SDK 19+
- When selecting media from external storage (SD Card) on a device running SDK 19+ I was receiving a null reference. It appears the ("primary".equalsIgnoreCase(type)) was never met and would just return "". I added an else case to handle this with the getExternalMediaDirs() call.

Fix for SDK 26+
- When selecting media from internal storage Long.valueOf(id) would crash NumberFormatException since the id is a URI. This was changed on Android 26+. I added a check for "raw" and return the URI directly in that case.