### PR TITLE
Fix no result returned on back pressed

### DIFF
--- a/libary/src/main/java/net/alhazmy13/mediapicker/Image/ImageActivity.java
+++ b/libary/src/main/java/net/alhazmy13/mediapicker/Image/ImageActivity.java
@@ -141,6 +141,12 @@ public class ImageActivity extends AppCompatActivity {
 
     }
 
+    @Override
+    public void onBackPressed() {
+        setResult(RESULT_CANCELED);
+        super.onBackPressed();
+    }
+
     private void startActivityFromGallery() {
         mImgConfig.isImgFromCamera = false;
         Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);

--- a/libary/src/main/java/net/alhazmy13/mediapicker/Video/VideoActivity.java
+++ b/libary/src/main/java/net/alhazmy13/mediapicker/Video/VideoActivity.java
@@ -325,12 +325,19 @@ public class VideoActivity extends AppCompatActivity {
                     // Permission Denied
                     Toast.makeText(VideoActivity.this, getString(R.string.media_picker_some_permission_is_denied), Toast.LENGTH_SHORT)
                             .show();
+                    onBackPressed();
                 }
 
                 break;
             default:
                 super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
+    }
+
+    @Override
+    public void onBackPressed() {
+        setResult(RESULT_CANCELED);
+        super.onBackPressed();
     }
 
     private static class CompresVideoTask extends AsyncTask<Void, Void, Void> {


### PR DESCRIPTION
There was an issue where the media picker stayed open after back presses. I fixed this by setting the result to cancelled. 